### PR TITLE
Fix header blocking content when accessing toc links

### DIFF
--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -125,6 +125,10 @@ h3 a:hover, h3 a:active {
     color: #ffffff !important;
 }
 
+html {
+    scroll-padding-top: 100px;
+}
+
 /* move TOC to left side if browser is wide enough */
 @media only screen and (min-width: 1150px) {
     #toc-cont {
@@ -171,5 +175,11 @@ h3 a:hover, h3 a:active {
     #radiator-links, #social-links, #toc-cont, #toc-cont *
     {
         display: none !important;
+    }
+}
+
+@media only screen and (min-width: 769px) {
+    html {
+        scroll-padding-top: 50px;
     }
 }


### PR DESCRIPTION
When accessing toc links, the content header was blocked by the page header. This is now fixed with html scroll padding.